### PR TITLE
Fix incorrect explanation

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -21,7 +21,7 @@ Question: If $x^2+1=2$, what is $x$?
 [ ] 2
 
 Explanation:
-$x=\sqrt{2-1}=\sqrt{1}=\pm 1$. So the answer is A and C!
+$x^2=2-1=1$, so $x$ has two solutions: $-1$ and $1$.
 ???
 
 We hope you have fun!


### PR DESCRIPTION
This explanation indicates that the square root of 1 is plus or minus 1, which is incorrect. x^2 = 1 has two solutions, however, so the explanation has been updated to reflect that.